### PR TITLE
Refactor apply task process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rustls-pemfile = "2"
 rcgen          = "0.14.8"
 tokio-rustls   = { version = "0.26.4", default-features = false, features = ["ring", "tls12"] }
 
-taskvisor = { version = "0.1.2" }
+taskvisor = { version = "0.1.3" }
 
 solti-tls        = { path = "crates/solti-tls",        version = "0.0.2" }
 solti-model      = { path = "crates/solti-model",      version = "0.0.2" }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - task: helpers:proto/vendor
         vars:
-          proto_ref: "v0.0.1"
+          proto_ref: "v0.0.2"
           MAPPINGS: |
             solti/task crates/solti-api/proto/solti/task
             solti/discover crates/solti-discover/proto/solti/discover

--- a/crates/solti-api/src/grpc.rs
+++ b/crates/solti-api/src/grpc.rs
@@ -130,6 +130,30 @@ where
         .await
     }
 
+    async fn apply_task(
+        &self,
+        request: Request<proto_api::ApplyTaskRequest>,
+    ) -> Result<Response<proto_api::ApplyTaskResponse>, Status> {
+        self.instrument("ApplyTask", async move {
+            let req = request.into_inner();
+
+            let spec = req
+                .spec
+                .ok_or_else(|| Status::invalid_argument("missing spec"))?;
+
+            let spec =
+                crate::convert::convert_create_spec(spec).map_err(|e: ApiError| Status::from(e))?;
+
+            debug!(slot = %spec.slot(), kind = ?spec.kind(), "grpc: applying task");
+            let task_id = self.handler.apply_task(spec).await.map_err(Status::from)?;
+
+            Ok(Response::new(proto_api::ApplyTaskResponse {
+                task_id: task_id.to_string(),
+            }))
+        })
+        .await
+    }
+
     async fn get_task_status(
         &self,
         request: Request<proto_api::GetTaskStatusRequest>,

--- a/crates/solti-api/src/handler.rs
+++ b/crates/solti-api/src/handler.rs
@@ -6,7 +6,9 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use solti_model::{OutputEvent, Task, TaskId, TaskPage, TaskQuery, TaskRun, TaskSpec};
+use solti_model::{
+    AdmissionPolicy, OutputEvent, Task, TaskId, TaskPage, TaskQuery, TaskRun, TaskSpec,
+};
 use tokio_stream::Stream;
 
 use crate::error::ApiError;
@@ -30,6 +32,7 @@ pub type OutputEventStream = Pin<Box<dyn Stream<Item = OutputEvent> + Send + 'st
 /// | Method             | HTTP                              | gRPC                |
 /// |--------------------|-----------------------------------|---------------------|
 /// | `submit_task`      | `POST   /api/v1/tasks`            | `SubmitTask`        |
+/// | `apply_task`       | `PUT    /api/v1/tasks`            | `ApplyTask`         |
 /// | `get_task_status`  | `GET    /api/v1/tasks/{id}`       | `GetTaskStatus`     |
 /// | `query_tasks`      | `GET    /api/v1/tasks`            | `ListTasks`         |
 /// | `list_task_runs`   | `GET    /api/v1/tasks/{id}/runs`  | `ListTaskRuns`      |
@@ -39,6 +42,13 @@ pub type OutputEventStream = Pin<Box<dyn Stream<Item = OutputEvent> + Send + 'st
 pub trait ApiHandler: Send + Sync + 'static {
     /// Submit a new task for execution.
     async fn submit_task(&self, spec: TaskSpec) -> Result<TaskId, ApiError>;
+
+    /// Apply a spec to its slot.
+    /// Returns the id of the task running in the slot after apply.
+    async fn apply_task(&self, spec: TaskSpec) -> Result<TaskId, ApiError> {
+        self.submit_task(spec.with_admission(AdmissionPolicy::Replace))
+            .await
+    }
 
     /// Get current status of a task by ID.
     async fn get_task_status(&self, id: &TaskId) -> Result<Option<Task>, ApiError>;

--- a/crates/solti-api/src/http.rs
+++ b/crates/solti-api/src/http.rs
@@ -5,14 +5,15 @@
 //!
 //! _the examples below show the current value (`v1`)_.
 //!
-//! | Method | Endpoint                    | Handler              |
-//! |--------|-----------------------------|----------------------|
-//! | POST   | `/api/v1/tasks`             | submit               |
-//! | GET    | `/api/v1/tasks`             | list (query params)  |
-//! | GET    | `/api/v1/tasks/{id}`        | get status           |
-//! | GET    | `/api/v1/tasks/{id}/runs`   | list runs            |
-//! | GET    | `/api/v1/tasks/{id}/logs`   | live-tail SSE stream |
-//! | DELETE | `/api/v1/tasks/{id}`        | delete (stop+purge)  |
+//! | Method | Endpoint                    | Handler                   |
+//! |--------|-----------------------------|---------------------------|
+//! | POST   | `/api/v1/tasks`             | submit                    |
+//! | PUT    | `/api/v1/tasks`             | apply (supersede/install) |
+//! | GET    | `/api/v1/tasks`             | list (query params)       |
+//! | GET    | `/api/v1/tasks/{id}`        | get status                |
+//! | GET    | `/api/v1/tasks/{id}/runs`   | list runs                 |
+//! | GET    | `/api/v1/tasks/{id}/logs`   | live-tail SSE stream      |
+//! | DELETE | `/api/v1/tasks/{id}`        | delete (stop+purge)       |
 
 use std::sync::Arc;
 
@@ -27,7 +28,7 @@ use axum::{
         IntoResponse, Response,
         sse::{Event, KeepAlive, Sse},
     },
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
 };
 use serde::{Deserialize, de::DeserializeOwned};
 use solti_model::{OutputEvent, TaskId, TaskPhase, TaskQuery};
@@ -122,6 +123,7 @@ where
     pub fn router(self) -> Router {
         Router::new()
             .route(api_url!("/tasks"), post(submit_task::<H>))
+            .route(api_url!("/tasks"), put(apply_task::<H>))
             .route(api_url!("/tasks"), get(list_tasks::<H>))
             .route(api_url!("/tasks/{id}"), get(get_task_status::<H>))
             .route(api_url!("/tasks/{id}"), delete(delete_task::<H>))
@@ -160,6 +162,27 @@ where
         task_id: task_id.to_string(),
     };
     Ok((StatusCode::CREATED, Json(response)))
+}
+
+async fn apply_task<H>(
+    State(handler): State<Arc<H>>,
+    ApiJson(req): ApiJson<proto_api::ApplyTaskRequest>,
+) -> Result<impl IntoResponse, ApiError>
+where
+    H: ApiHandler,
+{
+    let spec = req
+        .spec
+        .ok_or_else(|| ApiError::InvalidRequest("missing spec".into()))?;
+    let spec = convert::convert_create_spec(spec)?;
+
+    debug!(slot = %spec.slot(), kind = ?spec.kind(), "applying task");
+    let task_id = handler.apply_task(spec).await?;
+
+    let response = proto_api::ApplyTaskResponse {
+        task_id: task_id.to_string(),
+    };
+    Ok((StatusCode::OK, Json(response)))
 }
 
 async fn get_task_status<H>(

--- a/crates/solti-core/src/supervisor/mod.rs
+++ b/crates/solti-core/src/supervisor/mod.rs
@@ -215,7 +215,8 @@ impl SupervisorApi {
             to_restart_policy(spec.restart())?,
             to_backoff_policy(spec.backoff())?,
             Some(Duration::from_millis(spec.timeout().as_millis())),
-        );
+        )
+        .with_slot(spec.slot().as_str());
         let controller_spec =
             ControllerSpec::new(to_admission_policy(spec.admission())?, task_spec);
 

--- a/crates/solti-model/src/resource/spec.rs
+++ b/crates/solti-model/src/resource/spec.rs
@@ -133,6 +133,15 @@ impl TaskSpec {
         self.runner_selector = Some(sel);
         self
     }
+
+    /// Override the admission policy (consuming builder-style).
+    ///
+    /// Used by the apply/upgrade path to force [`AdmissionPolicy::Replace`] regardless of the spec's declared admission.
+    #[inline]
+    pub fn with_admission(mut self, admission: AdmissionPolicy) -> Self {
+        self.admission = admission;
+        self
+    }
 }
 
 impl TaskSpec {
@@ -399,6 +408,12 @@ mod tests {
         assert_eq!(spec.slot(), "my-slot");
         assert_eq!(spec.timeout().as_millis(), 10_000);
         assert_eq!(spec.restart(), RestartPolicy::OnFailure);
+        assert_eq!(spec.admission(), AdmissionPolicy::Replace);
+    }
+
+    #[test]
+    fn with_admission_overrides_policy() {
+        let spec = valid_spec().with_admission(AdmissionPolicy::Replace);
         assert_eq!(spec.admission(), AdmissionPolicy::Replace);
     }
 

--- a/crates/solti-runner/src/id.rs
+++ b/crates/solti-runner/src/id.rs
@@ -1,7 +1,12 @@
 //! # Run identifier generation.
 //!
-//! [`RunId`] is a human-readable task name for taskvisor, formatted as `{runner}-{slot}-{seq}`.
-//! The sequence is process-global and monotonically increasing (starts at 1).
+//! [`RunId`] is the per-execution task name for taskvisor, formatted as `{runner}-{slot}-{seq}` and **unique per submission**
+//! (the sequence is a process-global counter).
+//!
+//! Uniqueness is intentional: the name identifies one *run instance* (used for events, logs, cgroup naming and per-task state tracking).
+//!
+//! It is NOT the admission slot.
+//! The stable slot is set separately via [`TaskSpec::with_slot`](taskvisor::TaskSpec::with_slot).
 //!
 //! See [`Runner::build_run_id`](crate::Runner::build_run_id) for the default id builder.
 
@@ -25,9 +30,8 @@ pub struct RunId {
 }
 
 impl RunId {
-    /// Human-readable id used as task name for taskvisor.
-    ///
-    /// Format: `{runner}-{slot}-{seq}`.
+    /// Per-execution task name for taskvisor.
+    /// Format: `{runner}-{slot}-{seq}`, unique per submission.
     #[inline]
     pub fn name(&self) -> &str {
         &self.name
@@ -46,16 +50,12 @@ impl RunId {
     }
 }
 
-/// Build a human-readable run id used as task name for taskvisor.
+/// Build the per-execution run id.
 ///
-/// Format: `{runner}-{slot}-{seq}`.
+/// The taskvisor task name is `{runner}-{slot}-{seq}` and **unique per call** — it identifies one run instance.
 /// - `runner` - Runner::name()
-/// - `slot`   - TaskSpec.slot
-/// - `seq`    - per-process decimal sequence
-///
-/// Returns both the formatted name and the raw sequence number,
-/// so callers that need the seq (e.g. for cgroup naming) don't
-/// have to parse it back out of the string.
+/// - `slot`   - TaskSpec.slot (logical)
+/// - `seq`    - per-process counter (also used verbatim for cgroup naming)
 pub fn make_run_id(runner_name: &str, slot: &str) -> RunId {
     let seq = next_seq();
     RunId {


### PR DESCRIPTION
## 📝 Description
- Add new flow with new `TaskApply` methods
- Pass the logical slot to the controller via `TaskSpec::with_slot` in `submit_with_task`

## 🔄 Related Issues
Resolves #46 

## ✅ Checklist
- [x] Documentation updated (README, rustdoc, examples)
- [x] Tests added/updated (if relevant)
- [x] No breaking changes introduced
- [x] CI passes locally

## Note
This changes depends on new taskvisor version: 0.1.3